### PR TITLE
Fix block_covariance remainder window handling

### DIFF
--- a/asrpy/asr_utils.py
+++ b/asrpy/asr_utils.py
@@ -501,7 +501,8 @@ def block_covariance(data, window=128):
         Block covariance.
     """
     n_ch, n_times = data.shape
-    U = np.zeros([len(np.arange(0, n_times - 1, window)), n_ch**2])
+    n_blocks = len(np.arange(0, n_times - 2, window))
+    U = np.zeros([n_blocks, n_ch**2])
     data = data.T
     for k in range(0, window):
         idx_range = np.minimum(n_times - 1,

--- a/tests/test_asr.py
+++ b/tests/test_asr.py
@@ -7,6 +7,7 @@ import numpy as np
 from scipy.io import loadmat
 
 from asrpy import ASR, asr_calibrate, asr_process, clean_windows
+from asrpy.asr_utils import block_covariance
 from mne.io import read_raw_eeglab
 from mne.datasets import testing
 
@@ -78,3 +79,9 @@ def test_clean_windows():
 
     # Ensure cleaned data matches sample mask
     assert cleaned.shape[1] == sample_mask[0].sum()
+
+
+def test_block_covariance_remainder_two():
+    data = np.random.randn(25, 26302)  # 26302 % 100 = 2
+    out = block_covariance(data, window=100)
+    assert out.shape == (263, 25 * 25)


### PR DESCRIPTION
## Summary
- Align block count with idx_range in block_covariance to avoid reshape errors when samples are not divisible by window.
- Add regression test covering the remainder case.

## Repro
```python
import numpy as np
from asrpy.asr_utils import block_covariance
data = np.random.randn(25, 26302)
block_covariance(data, window=100)
```

Tests
pytest